### PR TITLE
Fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ CFLAGS	:=	-g -Wall -O3 -mword-relocations \
 			-fomit-frame-pointer -ffast-math \
 			$(ARCH)
 
-CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -DARM_ARCH -w -DLAUNCHER_PATH='"$(filepath)$(name)"'
+CFLAGS	+=	$(INCLUDE) -DARM11 -D_3DS -DARM_ARCH -DLAUNCHER_PATH='"$(filepath)$(name)"'
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11 -w
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ APP_AUTHOR	?=	patois
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard
 
-CFLAGS	:=	-g -Wall -O3 -mword-relocations \
+CFLAGS	:=	-g -Wall -Wextra -O3 -mword-relocations \
 			-fomit-frame-pointer -ffast-math \
 			$(ARCH)
 

--- a/include/brahma.h
+++ b/include/brahma.h
@@ -2,6 +2,8 @@
 
 #include "exploitdata.h"
 
+u32 brahma_init (void);
+u32 brahma_exit (void);
 s32 load_arm9_payload (char *filename);
 s32 load_arm9_payload_from_mem (u8* data, u32 dsize);
 void redirect_codeflow (u32 *dst_addr, u32 *src_addr);
@@ -16,10 +18,6 @@ s32 firm_reboot ();
 #define ARM_JUMPOUT 0xE51FF004 // LDR PC, [PC, -#04]
 #define ARM_RET     0xE12FFF1E // BX LR
 #define ARM_NOP     0xE1A00000 // NOP
-
-static u8  *g_ext_arm9_buf;
-static u32 g_ext_arm9_size = 0;
-static s32 g_ext_arm9_loaded = 0;
 
 extern void *arm11_start;
 extern void *arm11_end;

--- a/include/exploitdata.h
+++ b/include/exploitdata.h
@@ -17,13 +17,13 @@
 /* any changes to this structure must also be applied to
    the data structure following the 'arm11_globals_start'
    label of arm11.s */
-typedef struct arm11_shared_data {
+struct arm11_shared_data {
 	u32 va_pdn_regs;
 	u32 va_pxi_regs;
 	u32 va_hook1_ret;
 };
 
-typedef struct exploit_data {
+struct exploit_data {
 
 	u32 firm_version;
 	u32 sys_model; // mask
@@ -40,9 +40,6 @@ typedef struct exploit_data {
 	u32 va_pdn_regs;
 	u32 va_pxi_regs;
 };
-
-static struct exploit_data g_expdata;
-static struct arm11_shared_data g_arm11shared;
 
 // add all vulnerable systems below
 static const struct exploit_data supported_systems[] = {

--- a/include/exploitdata.h
+++ b/include/exploitdata.h
@@ -48,26 +48,26 @@ static const struct exploit_data supported_systems[] = {
 		SYS_MODEL_NEW_3DS, // model
 		0xDFFE7A50,        // VA of 1st hook for firmlaunch
 		0xDFFF4994,        // VA of 2nd hook for firmlaunch
-		0xFFF28A58,        // VA of return address from 1st hook 
+		0xFFF28A58,        // VA of return address from 1st hook
 		0xE0000000,        // VA of FCRAM
 		0xDFFF4000,        // VA of lower mapped exception handler base
 		0xFFFF0000,        // VA of upper mapped exception handler base
 		0xFFF158F8,        // VA of the KernelSetState syscall (upper mirror)
 		0xFFFBE000,        // VA PDN registers
-		0xFFFC0000         // VA PXI registers		
+		0xFFFC0000         // VA PXI registers
 	},
 	{
 		0x022C0600,        // FIRM version
 		SYS_MODEL_NEW_3DS, // model
 		0xDFFE7A50,        // VA of 1st hook for firmlaunch
 		0xDFFF4994,        // VA of 2nd hook for firmlaunch
-		0xFFF28A58,        // VA of return address from 1st hook 
+		0xFFF28A58,        // VA of return address from 1st hook
 		0xE0000000,        // VA of FCRAM
 		0xDFFF4000,        // VA of lower mapped exception handler base
 		0xFFFF0000,        // VA of upper mapped exception handler base
 		0xFFF158F8,        // VA of the KernelSetState syscall (upper mirror)
 		0xFFFBE000,        // VA PDN registers
-		0xFFFC0000         // VA PXI registers		
+		0xFFFC0000         // VA PXI registers
 	},
 	{
 		0x02220000,

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,4 +1,7 @@
 #pragma once
 
 void InvalidateEntireInstructionCache (void);
+void CleanEntireDataCache (void);
+void DisableInterrupts (void);
+void EnableInterrupts (void);
 void InvalidateEntireDataCache (void);

--- a/source/arm11.s
+++ b/source/arm11.s
@@ -15,13 +15,13 @@ hook1:
 	BL              busy_spin
 
 	MOV             R0, #0
-	BL              pxi_send	
-	
+	BL              pxi_send
+
 	BL              pxi_sync
-	
+
 	MOV             R0, #0x10000
 	BL              pxi_send
-	
+
 	BL              pxi_recv
 	BL              pxi_recv
 	BL              pxi_recv
@@ -59,17 +59,17 @@ hook2:
 @ to take control over the arm9 core
 hijack_arm9:
 	@ init
-	LDR             R0, pa_arm11_code 
-	MOV             R1, #0 
+	LDR             R0, pa_arm11_code
+	MOV             R1, #0
 	STR             R1, [R0]
-	
+
 	@ load physical addresses
 	LDR             R10, pa_firm_header
 	LDR             R9, pa_arm9_payload
 	LDR             R8, pa_io_mem
-	
+
 	@ send pxi cmd 0x44846
-	LDR             R1, pa_pxi_regs 
+	LDR             R1, pa_pxi_regs
 	LDR             R2, some_pxi_cmd
 	STR             R2, [R1, #8]
 
@@ -77,15 +77,15 @@ wait_arm9_loop:
 	LDRB            R0, [R8]
 	ANDS            R0, R0, #1
 	BNE	            wait_arm9_loop
-	
+
 	@ overwrite orig entry point with FCRAM addr
 	@ this exploits the race condition bug
-	STR             R9, [R10, #0x0C] 	
+	STR             R9, [R10, #0x0C]
 
 	LDR             R0, pa_arm11_code
 wait_arm11_loop:
 	LDR	            R1, [r0]
-	CMP             R1, #0  
+	CMP             R1, #0
 	BEQ             wait_arm11_loop
 	BX              R1
 
@@ -126,14 +126,14 @@ busy_spin:
 	SUBS            R0, R0, #2
 	NOP
 	BGT             busy_spin
-	BX              LR 
+	BX              LR
 
 pdn_send:
 	LDR             R1, va_pdn_regs
 	STRB            R0, [R1, #0x230]
 	BX              LR
-	
-pxi_send:  
+
+pxi_send:
 	LDR             R1, va_pxi_regs
 loc_1020D0:
 	LDRH            R2, [R1,#4]
@@ -144,7 +144,7 @@ loc_1020D0:
 
 pxi_recv:
 	LDR             R0, va_pxi_regs
-loc_1020FC:                              
+loc_1020FC:
 	LDRH            R1, [R0,#4]
 	TST             R1, #0x100
 	BNE             loc_1020FC

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -23,10 +23,10 @@ static struct arm11_shared_data g_arm11shared;
 GSP_FramebufferInfo topFramebufferInfo, bottomFramebufferInfo;
 
 /* should be the very first call. allocates heap buffer
-   for ARM9 payload */ 
+   for ARM9 payload */
 u32 brahma_init (void) {
 	g_ext_arm9_buf = memalign(0x1000, ARM9_PAYLOAD_MAX_SIZE);
-	return (g_ext_arm9_buf != 0);	
+	return (g_ext_arm9_buf != 0);
 }
 
 /* call upon exit */
@@ -34,21 +34,21 @@ u32 brahma_exit (void) {
 	if (g_ext_arm9_buf) {
 		free(g_ext_arm9_buf);
 	}
-	return 1;	
+	return 1;
 }
 
 /* overwrites two instructions (8 bytes in total) at src_addr
-   with code that redirects execution to dst_addr */ 
+   with code that redirects execution to dst_addr */
 void redirect_codeflow (u32 *dst_addr, u32 *src_addr) {
 	*(src_addr + 1) = (u32)dst_addr;
-	*src_addr = ARM_JUMPOUT;	
+	*src_addr = ARM_JUMPOUT;
 }
 
 /* fills exploit_data structure with information that is specific
    to 3DS model and firmware version
-   returns: 0 on failure, 1 on success */ 
+   returns: 0 on failure, 1 on success */
 s32 get_exploit_data (struct exploit_data *data) {
-	u32 fversion = 0;    
+	u32 fversion = 0;
 	u8  isN3DS = 0;
 	u32 i;
 	s32 result = 0;
@@ -78,7 +78,7 @@ s32 setup_exploit_data (void) {
 	s32 result = 0;
 
 	if (get_exploit_data(&g_expdata)) {
-		/* copy data required by code running in ARM11 svc mode */	
+		/* copy data required by code running in ARM11 svc mode */
 		g_arm11shared.va_hook1_ret = g_expdata.va_hook1_ret;
 		g_arm11shared.va_pdn_regs = g_expdata.va_pdn_regs;
 		g_arm11shared.va_pxi_regs = g_expdata.va_pxi_regs;
@@ -96,7 +96,7 @@ s32 recv_arm9_payload (void) {
 	struct sockaddr_in client_addr;
 	u32 addrlen = sizeof(client_addr);
 	s32 sflags = 0;
-		
+
 	if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
 		printf("[!] Error: socket()\n");
 		return 0;
@@ -187,7 +187,7 @@ s32 load_arm9_payload (char *filename) {
 	u32 fsize = 0;
 
 	if (!filename)
-		return result; 
+		return result;
 
 	FILE *f = fopen(filename, "rb");
 	if (f) {
@@ -216,7 +216,7 @@ s32 load_arm9_payload_from_mem (u8* data, u32 dsize) {
 		memcpy(g_ext_arm9_buf, data, dsize);
 		result = g_ext_arm9_loaded = 1;
 	}
-	
+
 	return result;
 }
 
@@ -228,7 +228,7 @@ s32 load_arm9_payload_from_mem (u8* data, u32 dsize) {
      code.
      Thus, the format of ARM9 payload written for Brahma is the following:
      - a branch instruction at offset 0 and
-     - a placeholder (u32) at offset 4 (=ARM9 entrypoint) */ 
+     - a placeholder (u32) at offset 4 (=ARM9 entrypoint) */
 s32 map_arm9_payload (void) {
 	void *src;
 	void *dst;
@@ -251,7 +251,7 @@ s32 map_arm9_payload (void) {
 		memcpy(dst, src, size);
 		result = 1;
 	}
-	
+
 	return result;
 }
 
@@ -267,7 +267,7 @@ s32 map_arm11_payload (void) {
 	dst = (void *)(g_expdata.va_exc_handler_base_W + OFFS_EXC_HANDLER_UNUSED);
 	size = (u8 *)&arm11_end - (u8 *)&arm11_start;
 
-	// TODO: sanitize 'size' 
+	// TODO: sanitize 'size'
 	if (size) {
 		memcpy(dst, src, size);
 		result_a = 1;
@@ -276,7 +276,7 @@ s32 map_arm11_payload (void) {
 	offs = size;
 	src = &g_arm11shared;
 	size = sizeof(g_arm11shared);
-	
+
 	dst = (u8 *)(g_expdata.va_exc_handler_base_W +
 	      OFFS_EXC_HANDLER_UNUSED + offs);
 
@@ -293,7 +293,7 @@ void exploit_arm9_race_condition (void) {
 
 	s32 (* const _KernelSetState)(u32, u32, u32, u32) =
 	    (void *)g_expdata.va_kernelsetstate;
-	
+
 	asm volatile ("clrex");
 
 	/* copy ARM11 payload and console specific data */
@@ -303,11 +303,11 @@ void exploit_arm9_race_condition (void) {
 
 		/* patch ARM11 kernel to force it to execute
 		   our code (hook1 and hook2) as soon as a
-		   "firmlaunch" is triggered */ 	 
+		   "firmlaunch" is triggered */
 		redirect_codeflow((u32 *)(g_expdata.va_exc_handler_base_X +
 		                  OFFS_EXC_HANDLER_UNUSED),
 		                  (u32 *)g_expdata.va_patch_hook1);
-	
+
 		redirect_codeflow((u32 *)(PA_EXC_HANDLER_BASE +
 		                  OFFS_EXC_HANDLER_UNUSED + 4),
 		                  (u32 *)g_expdata.va_patch_hook2);
@@ -316,7 +316,7 @@ void exploit_arm9_race_condition (void) {
 		InvalidateEntireInstructionCache();
 
 		// trigger ARM9 code execution through "firmlaunch"
-		_KernelSetState(0, 0, 2, 0);		
+		_KernelSetState(0, 0, 2, 0);
 		// prev call shouldn't ever return
 	}
 	return;
@@ -326,7 +326,7 @@ void exploit_arm9_race_condition (void) {
    but just to be on the safe side) */
 s32 priv_firm_reboot (void) {
     __asm__ volatile ("cpsid aif");
-	
+
     // Save the framebuffers for arm9,
     u32 *save = (u32 *)(g_expdata.va_fcram_base + 0x3FFFE00);
     save[0] = (u32)topFramebufferInfo.framebuf0_vaddr;
@@ -339,7 +339,7 @@ s32 priv_firm_reboot (void) {
     save[2] += 0xC000000;
 
     exploit_arm9_race_condition();
-	
+
     return 0;
 }
 
@@ -348,7 +348,7 @@ s32 priv_firm_reboot (void) {
    the handheld */
 s32 firm_reboot (void) {
 	s32 fail_stage = 0;
-	
+
 	fail_stage++; /* platform or firmware not supported, ARM11 exploit failure */
 	if (setup_exploit_data()) {
 		fail_stage++; /* failure while trying to corrupt svcCreateThread() */

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -231,7 +231,7 @@ s32 load_arm9_payload_from_mem (u8* data, u32 dsize) {
      - a placeholder (u32) at offset 4 (=ARM9 entrypoint) */
 s32 map_arm9_payload (void) {
 	void *src;
-	void *dst;
+	volatile void *dst;
 
 	u32 size = 0;
 	s32 result = 0;
@@ -248,7 +248,7 @@ s32 map_arm9_payload (void) {
 	}
 
 	if (size <= ARM9_PAYLOAD_MAX_SIZE) {
-		memcpy(dst, src, size);
+		memcpy((void *)dst, src, size);
 		result = 1;
 	}
 
@@ -257,7 +257,7 @@ s32 map_arm9_payload (void) {
 
 s32 map_arm11_payload (void) {
 	void *src;
-	void *dst;
+	volatile void *dst;
 	u32 size = 0;
 	u32 offs;
 	s32 result_a = 0;
@@ -269,7 +269,7 @@ s32 map_arm11_payload (void) {
 
 	// TODO: sanitize 'size'
 	if (size) {
-		memcpy(dst, src, size);
+		memcpy((void *)dst, src, size);
 		result_a = 1;
 	}
 
@@ -282,7 +282,7 @@ s32 map_arm11_payload (void) {
 
 	// TODO sanitize 'size'
 	if (result_a && size) {
-		memcpy(dst, src, size);
+		memcpy((void *)dst, src, size);
 		result_b = 1;
 	}
 

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -247,7 +247,7 @@ s32 map_arm9_payload (void) {
 		size = g_ext_arm9_size;
 	}
 
-	if (!size && size <= ARM9_PAYLOAD_MAX_SIZE) {
+	if (size <= ARM9_PAYLOAD_MAX_SIZE) {
 		memcpy(dst, src, size);
 		result = 1;
 	}

--- a/source/brahma.c
+++ b/source/brahma.c
@@ -50,7 +50,7 @@ void redirect_codeflow (u32 *dst_addr, u32 *src_addr) {
 s32 get_exploit_data (struct exploit_data *data) {
 	u32 fversion = 0;    
 	u8  isN3DS = 0;
-	s32 i;
+	u32 i;
 	s32 result = 0;
 	u32 sysmodel = SYS_MODEL_NONE;
 
@@ -247,7 +247,7 @@ s32 map_arm9_payload (void) {
 		size = g_ext_arm9_size;
 	}
 
-	if (size >= 0 && size <= ARM9_PAYLOAD_MAX_SIZE) {
+	if (!size && size <= ARM9_PAYLOAD_MAX_SIZE) {
 		memcpy(dst, src, size);
 		result = 1;
 	}

--- a/source/hid.c
+++ b/source/hid.c
@@ -1,7 +1,8 @@
 #include <3ds.h>
+#include <stdio.h>
 
 /* loop until key is pressed */
-u32 wait_key (void) {
+void wait_key (void) {
 	hidScanInput();
 	u32 old_kDown, kDown;
 	old_kDown = hidKeysDown();
@@ -17,7 +18,6 @@ u32 wait_key (void) {
 		gfxFlushBuffers();
 		gfxSwapBuffers();
 	}
-	return kDown;
 }
 
 /* convenience function */

--- a/source/main.c
+++ b/source/main.c
@@ -1,5 +1,6 @@
 #include <3ds.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "brahma.h"
 #include "hid.h"
 
@@ -7,7 +8,7 @@
 #define LAUNCHER_PATH "Cakes.dat"
 #endif
 
-s32 main (void) {
+int main (void) {
     // Initialize services
     gfxInitDefault();
 

--- a/source/utils.s
+++ b/source/utils.s
@@ -23,7 +23,7 @@ DisableInterrupts:
 	mrs r0, cpsr
 	CPSID I
 	bx lr
-	
+
 .global EnableInterrupts
 .type EnableInterrupts, %function
 EnableInterrupts:


### PR DESCRIPTION
The majority of them are trivial fixes, like static declarations being used outside the original file (solution: move to the correct file), missing includes (include them), missing castings (add castings), etc. Some of them are change the code slightly, like changing wait_key() type from int to void, since the return value was never used anyway, or changing main() from s32 to int because this is what GCC expects.

Other changes I am not too sure, like removing volatile from some variables. However, I tested in my O3DS 9.2.0-20U and it still works.

Since the objective of this commit is to remove warnings, I went and disabled the -w CLAGS, since this would be counter-productive.

This was part of the modifications from my fork [libcakebrah](https://github.com/m45t3r/libcakebrah). The objective of the fork was to allow using CakeBrah as a library, so I moved some things to other places and fixed the warnings so developers didn't need to disable warnings only because of CakeBrah. I may upstream the rest of the changes too if there is interest in them.
